### PR TITLE
Native::on() performance improvements

### DIFF
--- a/types/basics/item/types/native.coffee.md
+++ b/types/basics/item/types/native.coffee.md
@@ -4,6 +4,8 @@ Native @class
 	'use strict'
 
 	utils = require 'neft-utils'
+	log = require 'neft-log'
+	assert = require 'neft-assert'
 	nativeBridge = require 'neft-native'
 
 	module.exports = (Renderer, Impl, itemUtils) ->
@@ -39,6 +41,8 @@ Native::set(*String* propName, *Any* val)
 -----------------------------------------
 
 			set: (name, val) ->
+				assert.isString name
+
 				ctorName = utils.capitalize @constructor.__name__
 				id = @_impl.id
 				name = utils.capitalize name
@@ -50,6 +54,8 @@ Native::call(*String* funcName, *Any* args...)
 ----------------------------------------------
 
 			call: (name, args...) ->
+				assert.isString name
+
 				ctorName = utils.capitalize @constructor.__name__
 				id = @_impl.id
 				name = utils.capitalize name
@@ -62,12 +68,41 @@ Native::call(*String* funcName, *Any* args...)
 Native::on(*String* eventName, *Function* listener)
 ---------------------------------------------------
 
+			# nativeEventName -> item id -> [item, listeners...]
+			eventListeners = Object.create null
+
+			createNativeEventListener = (listeners, eventName) -> (id) ->
+				unless itemListeners = listeners[id]
+					log.warn "Got a native event '#{eventName}' for an item which " +
+						"didn't register a listener on this event; check if you " +
+						"properly call 'on()' method with a signal listener"
+					return
+
+				length = arguments.length
+				args = new Array length - 1
+				for i in [0...length-1] by 1
+					args[i] = arguments[i + 1]
+
+				item = itemListeners[0]
+				for i in [1...itemListeners.length] by 1
+					itemListeners[i].apply item, args
+
+				return
+
 			on: (name, func) ->
+				assert.isString name
+				assert.isFunction func
+
 				ctorName = utils.capitalize @constructor.__name__
-				id = @_impl.id
 				name = utils.capitalize name
-				eventName = "rendererOn#{ctorName}#{id}#{name}"
-				nativeBridge.on eventName, func
+				eventName = "rendererOn#{ctorName}#{name}"
+
+				unless listeners = eventListeners[eventName]
+					listeners = eventListeners[eventName] = Object.create(null)
+					nativeBridge.on eventName, createNativeEventListener(listeners, eventName)
+
+				itemListeners = listeners[@_impl.id] ?= [@]
+				itemListeners.push func
 				return
 
 		Native


### PR DESCRIPTION
Native::on() method now expects item id from the implementation as the first event parameter instead of inside the event name.
It will reduce the amount of event names which are stored in the neft-native module.

This changes need to be supported by the android and ios runtimes.